### PR TITLE
Fast projection check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ _site
 .jekyll-cache
 .jekyll-metadata
 vendor
+*.code-workspace

--- a/src/conditions.R
+++ b/src/conditions.R
@@ -64,7 +64,7 @@ if(nrow(WeatherZoneTable) == 0)
 
 # Ensure fuels crs can be converted to Lat / Long
 if(fuelsRaster %>% is.lonlat){stop("Incorrect coordinate system. Projected coordinate system required, please reproject your grids.")}
-tryCatch(fuelsRaster %>% project("epsg:4326"), error = function(e) stop("Error parsing provided Fuels map. Cannot calculate Latitude and Longitude from provided Fuels map, please check CRS."))
+tryCatch(fuelsRaster %>% project("EPSG:4326"), error = function(e) stop("Error parsing provided Fuels map. Cannot calculate Latitude and Longitude from provided Fuels map, please check CRS."))
 
 # Define function to check input raster for consistency
 checkSpatialInput <- function(x, name, checkProjection = T, warnOnly = F) {
@@ -126,7 +126,7 @@ uni <- function(df, colName) {
 cellFromLatLong <- function(x, lat, long) {
   # Convert list of lat and long to SpatVector, reproject to source crs
   points <- matrix(c(long, lat), ncol = 2) %>%
-    vect(crs = "+proj=longlat +datum=WGS84 +no_defs") %>%
+    vect(crs = "EPSG:4326") %>%
     project(x)
   
   # Get vector of cell ID's from points

--- a/src/conditions.R
+++ b/src/conditions.R
@@ -63,8 +63,8 @@ if(nrow(WeatherZoneTable) == 0)
 ## Check raster inputs for consistency ----
 
 # Ensure fuels crs can be converted to Lat / Long
-tryCatch(fuelsRaster %>% !is.lonlat , error = function(e) stop("Incorrect coordinate system. Projected coordinate system required, please reproject your grids."))
-tryCatch(fuelsRaster %>% crs %>% project("epsg:4326"), error = function(e) stop("Error parsing provided Fuels map. Cannot calculate Latitude and Longitude from provided Fuels map, please check CRS."))
+if(fuelsRaster %>% is.lonlat){stop("Incorrect coordinate system. Projected coordinate system required, please reproject your grids.")}
+tryCatch(fuelsRaster %>% project("epsg:4326"), error = function(e) stop("Error parsing provided Fuels map. Cannot calculate Latitude and Longitude from provided Fuels map, please check CRS."))
 
 # Define function to check input raster for consistency
 checkSpatialInput <- function(x, name, checkProjection = T, warnOnly = F) {

--- a/src/conditions.R
+++ b/src/conditions.R
@@ -63,7 +63,7 @@ if(nrow(WeatherZoneTable) == 0)
 ## Check raster inputs for consistency ----
 
 # Ensure fuels crs can be converted to Lat / Long
-tryCatch(fuelsRaster %>% project("+proj=longlat"), error = function(e) stop("Error parsing provided Fuels map. Cannot calculate Latitude and Longitude from provided Fuels map, please check CRS."))
+tryCatch(fuelsRaster %>% crs %>% project("epsg:4326"), error = function(e) stop("Error parsing provided Fuels map. Cannot calculate Latitude and Longitude from provided Fuels map, please check CRS."))
 
 # Define function to check input raster for consistency
 checkSpatialInput <- function(x, name, checkProjection = T, warnOnly = F) {

--- a/src/conditions.R
+++ b/src/conditions.R
@@ -63,6 +63,7 @@ if(nrow(WeatherZoneTable) == 0)
 ## Check raster inputs for consistency ----
 
 # Ensure fuels crs can be converted to Lat / Long
+tryCatch(fuelsRaster %>% !is.lonlat , error = function(e) stop("Incorrect coordinate system. Projected coordinate system required, please reproject your grids."))
 tryCatch(fuelsRaster %>% crs %>% project("epsg:4326"), error = function(e) stop("Error parsing provided Fuels map. Cannot calculate Latitude and Longitude from provided Fuels map, please check CRS."))
 
 # Define function to check input raster for consistency

--- a/src/ignitions.R
+++ b/src/ignitions.R
@@ -64,6 +64,7 @@ if(nrow(ResampleOption) == 0) {
 ## Check raster inputs for consistency ----
 
 # Ensure fuels crs can be converted to Lat / Long
+tryCatch(fuelsRaster %>% !is.lonlat , error = function(e) stop("Incorrect coordinate system. Projected coordinate system required, please reproject your grids."))
 tryCatch(fuelsRaster %>% crs %>% project("epsg:4326"), error = function(e) stop("Error parsing provided Fuels map. Cannot calculate Latitude and Longitude from provided Fuels map, please check CRS."))
 
 # Define function to check input raster for consistency

--- a/src/ignitions.R
+++ b/src/ignitions.R
@@ -231,7 +231,7 @@ sampleLocations <- function(season, cause, firezone, data) {
   # Sample cells from probability map
   cells <- sample(ncell(maskedProbability), nrow(data), replace = T, prob = replace_na(maskedProbability[], 0)) 
   longlat <- as.points(fuelsRaster, na.rm = F)[cells] %>%
-    project("+proj=longlat") %>%
+    project("EPSG:4326") %>%
     crds
   
   # Update SyncroSim progress bar

--- a/src/ignitions.R
+++ b/src/ignitions.R
@@ -64,7 +64,7 @@ if(nrow(ResampleOption) == 0) {
 ## Check raster inputs for consistency ----
 
 # Ensure fuels crs can be converted to Lat / Long
-tryCatch(fuelsRaster %>% crs %>% project("+proj=longlat"), error = function(e) stop("Error parsing provided Fuels map. Cannot calculate Latitude and Longitude from provided Fuels map, please check CRS."))
+tryCatch(fuelsRaster %>% crs %>% project("epsg:4326"), error = function(e) stop("Error parsing provided Fuels map. Cannot calculate Latitude and Longitude from provided Fuels map, please check CRS."))
 
 # Define function to check input raster for consistency
 checkSpatialInput <- function(x, name, checkProjection = T, warnOnly = F) {

--- a/src/ignitions.R
+++ b/src/ignitions.R
@@ -64,8 +64,8 @@ if(nrow(ResampleOption) == 0) {
 ## Check raster inputs for consistency ----
 
 # Ensure fuels crs can be converted to Lat / Long
-tryCatch(fuelsRaster %>% !is.lonlat , error = function(e) stop("Incorrect coordinate system. Projected coordinate system required, please reproject your grids."))
-tryCatch(fuelsRaster %>% crs %>% project("epsg:4326"), error = function(e) stop("Error parsing provided Fuels map. Cannot calculate Latitude and Longitude from provided Fuels map, please check CRS."))
+if(fuelsRaster %>% is.lonlat){stop("Incorrect coordinate system. Projected coordinate system required, please reproject your grids.")}
+tryCatch(fuelsRaster %>% project("epsg:4326"), error = function(e) stop("Error parsing provided Fuels map. Cannot calculate Latitude and Longitude from provided Fuels map, please check CRS."))
 
 # Define function to check input raster for consistency
 checkSpatialInput <- function(x, name, checkProjection = T, warnOnly = F) {

--- a/src/ignitions.R
+++ b/src/ignitions.R
@@ -64,7 +64,7 @@ if(nrow(ResampleOption) == 0) {
 ## Check raster inputs for consistency ----
 
 # Ensure fuels crs can be converted to Lat / Long
-tryCatch(fuelsRaster %>% project("+proj=longlat"), error = function(e) stop("Error parsing provided Fuels map. Cannot calculate Latitude and Longitude from provided Fuels map, please check CRS."))
+tryCatch(fuelsRaster %>% crs %>% project("+proj=longlat"), error = function(e) stop("Error parsing provided Fuels map. Cannot calculate Latitude and Longitude from provided Fuels map, please check CRS."))
 
 # Define function to check input raster for consistency
 checkSpatialInput <- function(x, name, checkProjection = T, warnOnly = F) {


### PR DESCRIPTION
Based on previous feedback from @BadgerOnABike and @cptcitrus , there's no need to reproject the whole fuels map to ensure that R can extract lat-long from the raster. Also, it seems `project(x, "+proj=longlat")` is being deprecated, so I swapped that out as well.

I'm afraid I also not set up to test this on real data, so I'd appreciate some help testing if you guys have the time.

If this looks good, there are probably parallel changes to be made in the add on packages.

(This should probably also be sqaushed merge, sorry!)