### PR TITLE
Fix burning hours distribution

### DIFF
--- a/src/conditions.R
+++ b/src/conditions.R
@@ -45,6 +45,7 @@ FuelTypeTable <- datasheet(myScenario, "burnP3Plus_FuelType")
 FireZoneTable <- datasheet(myScenario, "burnP3Plus_FireZone")
 WeatherZoneTable <- datasheet(myScenario, "burnP3Plus_WeatherZone")
 DistributionValue <- datasheet(myScenario, "burnP3Plus_DistributionValue", optional = T, lookupsAsFactors = F)
+SeasonTable <- datasheet(myScenario, "burnP3Plus_Season", returnInvisible = T) %>% filter(is.na(IsAuto))
 
 # Load weather and burn condition table
 FireDurationTable <- datasheet(myScenario, "burnP3Plus_FireDuration", optional = T, lookupsAsFactors = F, returnInvisible = T)
@@ -76,6 +77,26 @@ if(nrow(HoursBurningTable) == 0) {
   updateRunLog("No hours burning per day distribution provided, defaulting to 4 hours of burning per burn day.", type = "warning")
   HoursBurningTable[1,"Mean"] <- 4
   saveDatasheet(myScenario, HoursBurningTable, "burnP3Plus_HoursPerDayBurning")
+}
+
+# If HoursBurningTable set to "All", then all seasons in the SeasonTable
+# not specified in the HoursBurningTable should also have that value
+if ("All" %in% HoursBurningTable$Season){
+  if (nrow(HoursBurningTable > 1)){
+    updateRunLog(
+      "Value provided for hours burning per day distribution for 'All' seasons will be applied to all seasons without distributions specified.", 
+      type = "info")
+  }
+  
+  for (s in SeasonTable$Name){
+    
+    if (!s %in% HoursBurningTable$Season){
+      newRow <- HoursBurningTable[HoursBurningTable$Season == "All", ]
+      newRow$Season <- s
+      HoursBurningTable <- HoursBurningTable %>%
+        add_row(newRow)
+    }
+  }
 }
 
 if(nrow(FireZoneTable) == 0)

--- a/src/conditions.R
+++ b/src/conditions.R
@@ -81,21 +81,21 @@ if(nrow(HoursBurningTable) == 0) {
 
 # If HoursBurningTable set to "All", then all seasons in the SeasonTable
 # not specified in the HoursBurningTable should also have that value
-if ("All" %in% HoursBurningTable$Season){
-  if (nrow(HoursBurningTable > 1)){
-    updateRunLog(
-      "Value provided for hours burning per day distribution for 'All' seasons will be applied to all seasons without distributions specified.", 
-      type = "info")
-  }
+if (!"All" %in% HoursBurningTable$Season){
+  HoursBurningTable[1, "Season"] <- "All"
+  HoursBurningTable[1, "Mean"] <- 4
+}
+
+for (s in SeasonTable$Name){
   
-  for (s in SeasonTable$Name){
-    
-    if (!s %in% HoursBurningTable$Season){
-      newRow <- HoursBurningTable[HoursBurningTable$Season == "All", ]
-      newRow$Season <- s
-      HoursBurningTable <- HoursBurningTable %>%
-        add_row(newRow)
-    }
+  if (!s %in% HoursBurningTable$Season){
+    msg <- paste0("No hours burning per day distribution provided for season ", s, 
+                  ". Defaulting to either 'All' or 4 hours of burning per burn day.")
+    updateRunLog(msg, type = "info")
+    newRow <- HoursBurningTable[HoursBurningTable$Season == "All", ]
+    newRow$Season <- s
+    HoursBurningTable <- HoursBurningTable %>%
+      add_row(newRow)
   }
 }
 

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package name="burnP3Plus" displayName="Burn-P3+ package for burn probability modeling" version="1.1.1" url="https://burnp3.github.io/BurnP3Plus/">
+<package name="burnP3Plus" displayName="Burn-P3+ package for burn probability modeling" version="1.1.2" url="https://burnp3.github.io/BurnP3Plus/">
 	<transformers>
 		<transformer name="Primary" isPrimary="True" isPipelineBased="True" configurationSheet="burnP3Plus_RunControl" className="SyncroSim.StochasticTime.StochasticTimeTransformer" classAssembly="SyncroSim.StochasticTime">
 			<include>


### PR DESCRIPTION
Fixed bug where if user sets the total hours burning per day for just "All", but there are more seasons in the project-scoped season table, then a cryptic error is thrown. The new functionality checks if a daily burning hours value is set for "All", then also apply that value for all other seasons that do not have a value provided.