### PR TITLE
Fix daily burning hours datasheet

### DIFF
--- a/src/conditions.R
+++ b/src/conditions.R
@@ -75,6 +75,7 @@ if(nrow(FireDurationTable) == 0) {
 
 if(nrow(HoursBurningTable) == 0) {
   updateRunLog("No hours burning per day distribution provided, defaulting to 4 hours of burning per burn day.", type = "warning")
+  HoursBurningTable[1, "Season"] <- "All" 
   HoursBurningTable[1,"Mean"] <- 4
   saveDatasheet(myScenario, HoursBurningTable, "burnP3Plus_HoursPerDayBurning")
 }
@@ -224,8 +225,13 @@ sampleFireDuration <- function(season, firezone, data){
   
   # Determine hours burning per day distribution type to use
   # This is a function of season only
-  filteredHoursBurningTable <- HoursBurningTable %>%
-    filter(Season == season | is.na(Season))
+  if (season %in% HoursBurningTable$Season){
+    filteredHoursBurningTable <- HoursBurningTable %>%
+      filter(Season == season)
+  } else {
+    filteredHoursBurningTable <- HoursBurningTable %>%
+      filter(is.na(Season))
+  }
   
   hoursBurningDistributionName <- filteredHoursBurningTable %>%
     pull(DistributionType)

--- a/src/conditions.R
+++ b/src/conditions.R
@@ -225,13 +225,8 @@ sampleFireDuration <- function(season, firezone, data){
   
   # Determine hours burning per day distribution type to use
   # This is a function of season only
-  if (season %in% HoursBurningTable$Season){
-    filteredHoursBurningTable <- HoursBurningTable %>%
-      filter(Season == season)
-  } else {
-    filteredHoursBurningTable <- HoursBurningTable %>%
-      filter(is.na(Season))
-  }
+  filteredHoursBurningTable <- HoursBurningTable %>%
+    filter(Season == season | is.na(Season))
   
   hoursBurningDistributionName <- filteredHoursBurningTable %>%
     pull(DistributionType)

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package name="burnP3Plus" displayName="Burn-P3+ package for burn probability modeling" version="1.1.2" url="https://burnp3.github.io/BurnP3Plus/">
+<package name="burnP3Plus" displayName="Burn-P3+ package for burn probability modeling" version="1.1.3" url="https://burnp3.github.io/BurnP3Plus/">
 	<transformers>
 		<transformer name="Primary" isPrimary="True" isPipelineBased="True" configurationSheet="burnP3Plus_RunControl" className="SyncroSim.StochasticTime.StochasticTimeTransformer" classAssembly="SyncroSim.StochasticTime">
 			<include>


### PR DESCRIPTION
Fixed daily burning hours datasheet so it can handle the following cases:

- Only include summer distribution
- Only include spring distribution
- Include both summer and spring distributions
- Include only summer, value of 4
- Include only spring, value of 4
- Include spring and summer, values of 2 and 4
- Include only "All", value of 4
- Do not include anything
- Include a value, but no season