### PR TITLE
Fix for conversions to scientific notation

### DIFF
--- a/src/burnProbability.R
+++ b/src/burnProbability.R
@@ -1,6 +1,7 @@
 # Clean global environment variables
 native_proj_lib <- Sys.getenv("PROJ_LIB")
 Sys.unsetenv("PROJ_LIB")
+options(scipen = 999)
 
 # Check and load packages ----
 library(rsyncrosim)

--- a/src/conditions.R
+++ b/src/conditions.R
@@ -1,6 +1,7 @@
 # Clean global environment variables
 native_proj_lib <- Sys.getenv("PROJ_LIB")
 Sys.unsetenv("PROJ_LIB")
+options(scipen = 999)
 
 # Check and load packages ----
 library(rsyncrosim)

--- a/src/ignitions.R
+++ b/src/ignitions.R
@@ -1,6 +1,7 @@
 # Clean global environment variables
 native_proj_lib <- Sys.getenv("PROJ_LIB")
 Sys.unsetenv("PROJ_LIB")
+options(scipen = 999)
 
 # Check and load packages ----
 library(rsyncrosim)


### PR DESCRIPTION
R was changing large integer values to scientific notation, resulting in invalid data type errors when trying to save these integer values back to SyncroSim datasheets. Kim Morrison ran into this when trying to run 100,000 iterations and R converted the 100,000 to 10e5.

