### PR TITLE
Fix bug when no weather/fire zone raster provided

### DIFF
--- a/src/burnProbability.R
+++ b/src/burnProbability.R
@@ -29,6 +29,8 @@ checkPackageVersion("tidyverse",  "2.0.0")
 checkPackageVersion("dplyr",      "1.1.2")
 checkPackageVersion("codetools",  "0.2.19")
 checkPackageVersion("data.table", "1.14.8")
+checkPackageVersion("terra",      "1.5.21")
+checkPackageVersion("sf",         "1.0.7")
 
 # Setup ----
 progressBar(type = "message", message = "Preparing inputs...")

--- a/src/conditions.R
+++ b/src/conditions.R
@@ -106,7 +106,7 @@ for (s in SeasonTable$Name){
 # Spread Event Days
 for (i in 1:nrow(FireDurationTable)){
   distName <- FireDurationTable$DistributionType[i]
-  if (is.null(distName)) next
+  if (is.na(distName)) next
   distValues <- DistributionValue %>% filter(Name == distName)
   if (nrow(distValues) == 0){
     stop(paste0("No values found in Distribution datasheet for Spread Event Days distribution: ", distName))
@@ -116,7 +116,7 @@ for (i in 1:nrow(FireDurationTable)){
 # Daily Burning Hours
 for (i in 1:nrow(HoursBurningTable)){
   distName <- HoursBurningTable$DistributionType[i]
-  if (is.null(distName)) next
+  if (is.na(distName)) next
   distValues <- DistributionValue %>% filter(Name == distName)
   if (nrow(distValues) == 0){
     stop(paste0("No values found in Distribution datasheet for Daily Burning Hours distribution: ", distName))

--- a/src/conditions.R
+++ b/src/conditions.R
@@ -323,7 +323,9 @@ if (!is.null(weatherZoneRaster)){
     ) %>%
     dplyr::select(-weatherzoneID)
 } else{
-  DeterministicIgnitionLocation$WeatherZone = WeatherZoneTable$Name
+  numIgnitions <- nrow(DeterministicIgnitionLocation)
+  weatherZoneSamples <- sample(WeatherZoneTable$Name, numIgnitions, replace = T)
+  DeterministicIgnitionLocation$WeatherZone <- weatherZoneSamples
 }
 
 if (!is.null(fireZoneRaster)){
@@ -334,7 +336,9 @@ if (!is.null(fireZoneRaster)){
     ) %>%
     dplyr::select(-firezoneID)
 } else{
-  DeterministicIgnitionLocation$FireZone = FireZoneTable$Name
+  numIgnitions <- nrow(DeterministicIgnitionLocation)
+  fireZoneSamples <- sample(FireZoneTable$Name, numIgnitions, replace = T)
+  DeterministicIgnitionLocation$FireZone <- fireZoneSamples
 }
 
 # Clean up

--- a/src/conditions.R
+++ b/src/conditions.R
@@ -106,7 +106,7 @@ for (s in SeasonTable$Name){
 # Spread Event Days
 for (i in 1:nrow(FireDurationTable)){
   distName <- FireDurationTable$DistributionType[i]
-  if (is.na(distName)) next
+  if (is.na(distName) | distName == "Gamma" | distName == "Normal") next
   distValues <- DistributionValue %>% filter(Name == distName)
   if (nrow(distValues) == 0){
     stop(paste0("No values found in Distribution datasheet for Spread Event Days distribution: ", distName))
@@ -116,7 +116,7 @@ for (i in 1:nrow(FireDurationTable)){
 # Daily Burning Hours
 for (i in 1:nrow(HoursBurningTable)){
   distName <- HoursBurningTable$DistributionType[i]
-  if (is.na(distName)) next
+  if (is.na(distName) | distName == "Gamma" | distName == "Normal") next
   distValues <- DistributionValue %>% filter(Name == distName)
   if (nrow(distValues) == 0){
     stop(paste0("No values found in Distribution datasheet for Daily Burning Hours distribution: ", distName))

--- a/src/conditions.R
+++ b/src/conditions.R
@@ -232,7 +232,6 @@ sampleGamma <- function(df, numSamples, defaultMean = 1, defaultSD = 1, defaultM
 
 # Define function to sample days burning and hours per day burning given season and fire zone
 sampleFireDuration <- function(season, firezone, data){
-  browser()
   # Determine fire duration distribution type to use
   # This is a function of season and firezone
   filteredFireDurationTable <- FireDurationTable %>%

--- a/src/conditions.R
+++ b/src/conditions.R
@@ -30,6 +30,8 @@ checkPackageVersion("rsyncrosim", "2.0.0")
 checkPackageVersion("tidyverse",  "2.0.0")
 checkPackageVersion("dplyr",      "1.1.2")
 checkPackageVersion("codetools",  "0.2.19")
+checkPackageVersion("terra",      "1.5.21")
+checkPackageVersion("sf",         "1.0.7")
 
 # Setup ----
 options(scipen = 100)
@@ -124,7 +126,7 @@ for (i in 1:nrow(HoursBurningTable)){
   }
 }
 
-if (nrow(DeterministicBurnCondition) > 0) {
+if (!all(is.na(DeterministicBurnCondition))) {
   updateRunLog("Values in Deterministic Burn Conditions datasheet are overwritten.", type = "warning")
 }
 

--- a/src/conditions.R
+++ b/src/conditions.R
@@ -102,6 +102,28 @@ for (s in SeasonTable$Name){
   }
 }
 
+# Check to ensure that distributions specified actually exist
+# Spread Event Days
+for (i in 1:nrow(FireDurationTable)){
+  distName <- FireDurationTable$DistributionType[i]
+  if (is.null(distName)) next
+  distValues <- DistributionValue %>% filter(Name == distName)
+  if (nrow(distValues) == 0){
+    stop(paste0("No values found in Distribution datasheet for Spread Event Days distribution: ", distName))
+  }
+}
+
+# Daily Burning Hours
+for (i in 1:nrow(HoursBurningTable)){
+  distName <- HoursBurningTable$DistributionType[i]
+  if (is.null(distName)) next
+  distValues <- DistributionValue %>% filter(Name == distName)
+  if (nrow(distValues) == 0){
+    stop(paste0("No values found in Distribution datasheet for Daily Burning Hours distribution: ", distName))
+  }
+}
+
+
 if(nrow(FireZoneTable) == 0)
   FireZoneTable <- data.frame(Name = "", ID = 0)
 if(nrow(WeatherZoneTable) == 0)

--- a/src/ignitions.R
+++ b/src/ignitions.R
@@ -58,6 +58,7 @@ ResampleOption <- datasheet(myScenario, "burnP3Plus_FireResampleOption", optiona
 ProbabilisticIgnitionLocation <- datasheet(myScenario, "burnP3Plus_ProbabilisticIgnitionLocation", optional = T, lookupsAsFactors = F, returnInvisible = T)
 IgnitionRestriction <- datasheet(myScenario, "burnP3Plus_IgnitionRestriction", optional = T, lookupsAsFactors = F, returnInvisible = T)
 IgnitionDistribution <- datasheet(myScenario, "burnP3Plus_IgnitionDistribution", optional = T, lookupsAsFactors = F, returnInvisible = T)
+DeterministicIgnitionLocation <- datasheet(myScenario, "burnP3Plus_DeterministicIgnitionLocation", optional = T, returnInvisible = T) %>% unique
 
 # Import relevant rasters, allowing for missing values
 fuelsRaster <- rast(datasheet(myScenario, "burnP3Plus_LandscapeRasters")[["FuelGridFileName"]])
@@ -102,6 +103,11 @@ for (i in 1:nrow(IgnitionsPerIteration)){
   if (nrow(distValues) == 0){
     stop(paste0("No values found in Distribution datasheet for Ignition Count distribution: ", distName))
   }
+}
+
+# Check if values in Deterministic Ignition Locations is empty
+if (nrow(DeterministicIgnitionLocation) > 0) {
+  updateRunLog("Values in Deterministic Ignition Location datasheet are overwritten.", type = "warning")
 }
 
 ## Check raster inputs for consistency ----
@@ -313,7 +319,12 @@ if(is.na(distributionName)) {
 # Otherwise sample from a user distribution
 } else {
   ignitionCountDistribution <- DistributionValue %>% filter(Name == distributionName)
-  numIgnitions <- sample(ignitionCountDistribution$Value, numIterations, replace = T, prob = ignitionCountDistribution$RelativeFrequency)
+  
+  if (nrow(ignitionCountDistribution) == 1) {
+    numIgnitions <- sample(rep(IgnitionsPerIteration$Value, 2), numIterations, replace = T)
+  } else {
+    numIgnitions <- sample(ignitionCountDistribution$Value, numIterations, replace = T, prob = ignitionCountDistribution$RelativeFrequency)
+  }
 }
   
 saveDatasheet(myScenario, data.frame(Iteration = iterations, Ignitions = numIgnitions), "burnP3Plus_DeterministicIgnitionCount", append = T)
@@ -374,7 +385,7 @@ DeterminisiticIgnitionLocation <-
   as.data.frame
 
 # Return output
-saveDatasheet(myScenario, DeterminisiticIgnitionLocation, "burnP3Plus_DeterministicIgnitionLocation", append = T)
+saveDatasheet(myScenario, DeterminisiticIgnitionLocation, "burnP3Plus_DeterministicIgnitionLocation", append = F)
 
 # Wrapup the SyncroSim progress bar
 progressBar("end")

--- a/src/ignitions.R
+++ b/src/ignitions.R
@@ -94,6 +94,16 @@ if(any(is.na(ProbabilisticIgnitionLocation$IgnitionGridFileName))) {
   stop("Not all Probabilistic Ignition Grids specified in the Ignition Location datasheet.")
 }
 
+# Check for ignition count distribution
+for (i in 1:nrow(IgnitionsPerIteration)){
+  distName <- IgnitionsPerIteration$DistributionType[i]
+  if (is.null(distName)) next
+  distValues <- DistributionValue %>% filter(Name == distName)
+  if (nrow(distValues) == 0){
+    stop(paste0("No values found in Distribution datasheet for Ignition Count distribution: ", distName))
+  }
+}
+
 ## Check raster inputs for consistency ----
 
 test.point <- vect(xyFromCell(fuelsRaster,1), crs = crs(fuelsRaster))

--- a/src/ignitions.R
+++ b/src/ignitions.R
@@ -323,7 +323,7 @@ if(is.na(distributionName)) {
   ignitionCountDistribution <- DistributionValue %>% filter(Name == distributionName)
   
   if (nrow(ignitionCountDistribution) == 1) {
-    numIgnitions <- sample(rep(IgnitionsPerIteration$Value, 2), numIterations, replace = T)
+    numIgnitions <- rep(IgnitionsPerIteration$Value, numIterations)
   } else {
     numIgnitions <- sample(ignitionCountDistribution$Value, numIterations, replace = T, prob = ignitionCountDistribution$RelativeFrequency)
   }

--- a/src/ignitions.R
+++ b/src/ignitions.R
@@ -29,6 +29,8 @@ checkPackageVersion("rsyncrosim", "2.0.0")
 checkPackageVersion("tidyverse",  "2.0.0")
 checkPackageVersion("dplyr",      "1.1.2")
 checkPackageVersion("codetools",  "0.2.19")
+checkPackageVersion("terra",      "1.5.21")
+checkPackageVersion("sf",         "1.0.7")
 
 # Setup ----
 options(scipen = 100)
@@ -106,7 +108,7 @@ for (i in 1:nrow(IgnitionsPerIteration)){
 }
 
 # Check if values in Deterministic Ignition Locations is empty
-if (nrow(DeterministicIgnitionLocation) > 0) {
+if (!all(is.na(DeterministicIgnitionLocation))) {
   updateRunLog("Values in Deterministic Ignition Location datasheet are overwritten.", type = "warning")
 }
 

--- a/src/ignitions.R
+++ b/src/ignitions.R
@@ -97,7 +97,7 @@ if(any(is.na(ProbabilisticIgnitionLocation$IgnitionGridFileName))) {
 # Check for ignition count distribution
 for (i in 1:nrow(IgnitionsPerIteration)){
   distName <- IgnitionsPerIteration$DistributionType[i]
-  if (is.null(distName)) next
+  if (is.na(distName)) next
   distValues <- DistributionValue %>% filter(Name == distName)
   if (nrow(distValues) == 0){
     stop(paste0("No values found in Distribution datasheet for Ignition Count distribution: ", distName))

--- a/src/ignitions.R
+++ b/src/ignitions.R
@@ -97,7 +97,7 @@ if(any(is.na(ProbabilisticIgnitionLocation$IgnitionGridFileName))) {
 # Check for ignition count distribution
 for (i in 1:nrow(IgnitionsPerIteration)){
   distName <- IgnitionsPerIteration$DistributionType[i]
-  if (is.na(distName)) next
+  if (is.na(distName) | distName == "Gamma" | distName == "Normal") next
   distValues <- DistributionValue %>% filter(Name == distName)
   if (nrow(distValues) == 0){
     stop(paste0("No values found in Distribution datasheet for Ignition Count distribution: ", distName))

--- a/src/ignitions.R
+++ b/src/ignitions.R
@@ -90,6 +90,10 @@ if(nrow(ResampleOption) == 0) {
   saveDatasheet(myScenario, ResampleOption, "burnP3Plus_FireResampleOption")
 }
 
+if(any(is.na(ProbabilisticIgnitionLocation$IgnitionGridFileName))) {
+  stop("Not all Probabilistic Ignition Grids specified in the Ignition Location datasheet.")
+}
+
 ## Check raster inputs for consistency ----
 
 test.point <- vect(xyFromCell(fuelsRaster,1), crs = crs(fuelsRaster))

--- a/src/package.xml
+++ b/src/package.xml
@@ -136,7 +136,7 @@
 	<dataSheet name="HoursPerDayBurning" displayName="Daily Burning Hours">
 		<column name="Iteration" dataType="Integer" validationType="WholeNumber" validationCondition="Greater" formula1="0" format="d" isVisible="False"/>
 		<column name="Timestep" dataType="Integer" validationType="WholeNumber" validationCondition="GreaterEqual" formula1="0" format="d" isVisible="False"/>
-		<column name="Season" dataType="Integer" validationType="Datasheet" formula1="Season" isOptional="True"/>
+		<column name="Season" dataType="Integer" validationType="Datasheet" formula1="Season" allowDbNull="False"/>
 		<column name="Mean" displayName="Daily Burning Hours" dataType="Double" validationType="Decimal" validationCondition="GreaterEqual" formula1="0.0" format="0.0" isOptional="True" initOptionalVisible="True"/>
 		<column name="DistributionType" displayName="Daily Burning Hours Distribution" dataType="Integer" validationType="Datasheet" formula1="Distribution" isOptional="True"/>
 		<column name="DistributionSD" displayName="Daily Burning Hours SD" dataType="Double" validationType="Decimal" validationCondition="GreaterEqual" formula1="0.0" format="0.0" isOptional="True"/>

--- a/src/package.xml
+++ b/src/package.xml
@@ -109,7 +109,7 @@
 		<column name="Timestep" dataType="Integer" validationType="WholeNumber" validationCondition="GreaterEqual" formula1="0" format="d" isVisible="False"/>
 		<column name="Season" dataType="Integer" validationType="Datasheet" formula1="Season" isOptional="True"/>
 		<column name="Cause" dataType="Integer" validationType="Datasheet" formula1="Cause" isOptional="True"/>
-		<column name="IgnitionGridFileName" displayName="Probabilistic Ignition Grid" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif"/>
+		<column name="IgnitionGridFileName" displayName="Probabilistic Ignition Grid" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif" allowDbNull="False"/>
 	</dataSheet>
 
 	<dataSheet name="IgnitionRestriction" displayName="Ignition Restrictions">

--- a/src/package.xml
+++ b/src/package.xml
@@ -194,23 +194,23 @@
 	</dataSheet>
 
 	<dataSheet name="WindGrid" displayName="Wind Grid" isSingleRow="True">
-		<column name="WindSpeed" displayName="Prevailing Wind Speed" dataType="Double" validationType="Decimal" validationCondition="Greater" formula1="0.0" format="0.0"/>
-		<column name="WindSpeedNorth" displayName="Wind Speed North" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif"/>
-		<column name="WindSpeedNorthEast" displayName="Wind Speed North East" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif"/>
-		<column name="WindSpeedEast" displayName="Wind Speed East" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif"/>
-		<column name="WindSpeedSouthEast" displayName="Wind Speed South East" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif"/>
-		<column name="WindSpeedSouth" displayName="Wind Speed South" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif"/>
-		<column name="WindSpeedSouthWest" displayName="Wind Speed South West" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif"/>
-		<column name="WindSpeedWest" displayName="Wind Speed West" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif"/>
-		<column name="WindSpeedNorthWest" displayName="Wind Speed North West" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif"/>
-		<column name="WindDirectionNorth" displayName="Wind Direction North" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif"/>
-		<column name="WindDirectionNorthEast" displayName="Wind Direction North East" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif"/>
-		<column name="WindDirectionEast" displayName="Wind Direction East" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif"/>
-		<column name="WindDirectionSouthEast" displayName="Wind Direction South East" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif"/>
-		<column name="WindDirectionSouth" displayName="Wind Direction South" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif"/>
-		<column name="WindDirectionSouthWest" displayName="Wind Direction South West" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif"/>
-		<column name="WindDirectionWest" displayName="Wind Direction West" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif"/>
-		<column name="WindDirectionNorthWest" displayName="Wind Direction North West" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif"/>
+		<column name="WindSpeed" displayName="Prevailing Wind Speed" dataType="Double" validationType="Decimal" validationCondition="Greater" formula1="0.0" format="0.0" allowDbNull="False"/>
+		<column name="WindSpeedNorth" displayName="Wind Speed North" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif" allowDbNull="False"/>
+		<column name="WindSpeedNorthEast" displayName="Wind Speed North East" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif" allowDbNull="False"/>
+		<column name="WindSpeedEast" displayName="Wind Speed East" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif" allowDbNull="False"/>
+		<column name="WindSpeedSouthEast" displayName="Wind Speed South East" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif" allowDbNull="False"/>
+		<column name="WindSpeedSouth" displayName="Wind Speed South" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif" allowDbNull="False"/>
+		<column name="WindSpeedSouthWest" displayName="Wind Speed South West" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif" allowDbNull="False"/>
+		<column name="WindSpeedWest" displayName="Wind Speed West" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif" allowDbNull="False"/>
+		<column name="WindSpeedNorthWest" displayName="Wind Speed North West" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif" allowDbNull="False"/>
+		<column name="WindDirectionNorth" displayName="Wind Direction North" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif" allowDbNull="False"/>
+		<column name="WindDirectionNorthEast" displayName="Wind Direction North East" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif" allowDbNull="False"/>
+		<column name="WindDirectionEast" displayName="Wind Direction East" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif" allowDbNull="False"/>
+		<column name="WindDirectionSouthEast" displayName="Wind Direction South East" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif" allowDbNull="False"/>
+		<column name="WindDirectionSouth" displayName="Wind Direction South" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif" allowDbNull="False"/>
+		<column name="WindDirectionSouthWest" displayName="Wind Direction South West" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif" allowDbNull="False"/>
+		<column name="WindDirectionWest" displayName="Wind Direction West" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif" allowDbNull="False"/>
+		<column name="WindDirectionNorthWest" displayName="Wind Direction North West" dataType="String" isExternalFile="True" isRaster="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif" allowDbNull="False"/>
 	</dataSheet>
 
 	<dataSheet name="GreenUp" displayName="Green Up">

--- a/src/package.xml
+++ b/src/package.xml
@@ -238,6 +238,7 @@
 
 	<dataSheet name="OutputOption" displayName="Output Options" isSingleRow="True">
 		<column name="FireStatistics" dataType="Boolean" displayName="Fire Statistics Table"/>
+		<record columns="FireStatistics" values="-1"/>
 	</dataSheet>
 
 	<dataSheet name="OutputOptionSpatial" displayName="Spatial Output Options" isSingleRow="True">

--- a/src/package.xml
+++ b/src/package.xml
@@ -142,6 +142,7 @@
 		<column name="DistributionSD" displayName="Daily Burning Hours SD" dataType="Double" validationType="Decimal" validationCondition="GreaterEqual" formula1="0.0" format="0.0" isOptional="True"/>
 		<column name="DistributionMin" displayName="Daily Burning Hours Min" dataType="Double" validationType="Decimal" validationCondition="GreaterEqual" formula1="0.0" format="0.0" isOptional="True"/>
 		<column name="DistributionMax" displayName="Daily Burning Hours Max" dataType="Double" validationType="Decimal" validationCondition="GreaterEqual" formula1="0.0" format="0.0" isOptional="True"/>
+		<validation validationType="Unique" columns="Season"/>
 	</dataSheet>
 
 	<dataSheet name="IgnitionDistribution" displayName="Ignition Distribution">
@@ -471,5 +472,7 @@
 		<item name="BurnMap" displayName ="Burn Map" dataSheet="OutputBurnMap" column="FileName" filter="Season"/>
 		<item name="AllPerimMap" displayName ="Individual Fire Burn Maps" dataSheet="OutputAllPerim" column="FileName"/>
 	</layout>
+
+	<updateProvider className="SyncroSim.Core.XMLUpdateProvider" classAssembly="SyncroSim.Core"/>
 
 </package>

--- a/src/updates/update-0.100.xml
+++ b/src/updates/update-0.100.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<update>
+<update comment="Legacy Update 1">
   <action code="Exec" condition="TableExists" criteria="burnP3Plus_Distribution">
     <item>ALTER TABLE burnP3Plus_Distribution ADD COLUMN IsAuto Integer</item>
     <item>INSERT INTO burnP3Plus_Distribution (ProjectID, Name, IsAuto) SELECT ProjectID, 'Normal', '-1' FROM core_Project</item>

--- a/src/updates/update-0.200.xml
+++ b/src/updates/update-0.200.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<update>
+<update comment="Legacy Update 2">
   <action code="Exec" condition="TableExists" criteria="burnP3Plus_DeterministicIgnitionLocation">
     <item>ALTER TABLE burnP3Plus_DeterministicIgnitionLocation ADD COLUMN Latitude Double</item>
     <item>ALTER TABLE burnP3Plus_DeterministicIgnitionLocation ADD COLUMN Longitude Double</item>

--- a/src/updates/update-0.300.xml
+++ b/src/updates/update-0.300.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<update>
+<update comment="Legacy Update 3">
   <action code="Exec" condition="TableNotExists" criteria="burnP3Plus_GreenUp">
     <item>CREATE TABLE burnP3Plus_GreenUp(GreenUpID INTEGER PRIMARY KEY, ScenarioID INTEGER, Season INTEGER, GreenUp INTEGER)</item>
   </action>

--- a/src/updates/update-0.400.xml
+++ b/src/updates/update-0.400.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<update>
+<update comment="Legacy Update 4">
   <action code="Exec" condition="TableExists" criteria="burnP3Plus_WindGrid">
     <item>ALTER TABLE burnP3Plus_WindGrid ADD COLUMN WindSpeed Double</item>
   </action>

--- a/src/updates/update-0.500.xml
+++ b/src/updates/update-0.500.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<update>
+<update comment="Legacy Update 5">
   <action code="Exec" condition="TableExists" criteria="burnP3Plus_Distribution">
     <item>INSERT INTO burnP3Plus_Distribution (ProjectID, Name, IsAuto) SELECT ProjectID, 'Gamma', '-1' FROM core_Project</item>
   </action>

--- a/src/updates/update-0.600.xml
+++ b/src/updates/update-0.600.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<update>
+<update comment="Legacy Update 6">
   <action code="Exec" condition="TableExists" criteria="burnP3Plus_OutputOptionSpatial">
     <item>ALTER TABLE burnP3Plus_OutputOptionSpatial ADD COLUMN AllPerim INTEGER</item>
   </action>

--- a/src/updates/update-0.700.xml
+++ b/src/updates/update-0.700.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<update>
+<update comment="Legacy Update 7">
   <action code="Exec" condition="TableNotExists" criteria="burnP3Plus_BatchOption">
     <item>CREATE TABLE burnP3Plus_BatchOption(BatchOptionID INTEGER PRIMARY KEY, BatchSize INTEGER)</item>
     <item>INSERT INTO burnP3Plus_BatchOption (BatchSize) VALUES (250)</item>

--- a/src/updates/update-0.800.xml
+++ b/src/updates/update-0.800.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<update>
+<update comment="Legacy Update 8">
   <action code="Exec" condition="TableExists" criteria="burnP3Plus_OutputOptionSpatial">
     <item>ALTER TABLE burnP3Plus_OutputOptionSpatial ADD COLUMN SeasonalBurnProbability INTEGER</item>
     <item>ALTER TABLE burnP3Plus_OutputOptionSpatial ADD COLUMN SeasonalRelativeBurnProbability INTEGER</item>

--- a/src/updates/update-0.900.xml
+++ b/src/updates/update-0.900.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<update>
+<update comment="Legacy Update 9">
   <action code="Exec" condition="TableExists" criteria="burnP3Plus_OutputFireStatistic">
     <item> CREATE TABLE temp_table AS SELECT * FROM burnP3Plus_OutputFireStatistic</item>
 

--- a/src/updates/update-2.000.xml
+++ b/src/updates/update-2.000.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<update comment="Add All to Season column in Daily Burning Hours if no season provided">
+  <action code="Exec" condition="TableExists" criteria="burnP3Plus_HoursPerDayBurning">
+    <item> UPDATE burnP3Plus_HoursPerDayBurning SET season = (SELECT SeasonID FROM burnP3Plus_Season WHERE Name = 'All') WHERE season IS NULL </item>
+  </action>
+</update>


### PR DESCRIPTION
When no weather or fire zone is provided, then the weather and fire zones provided in the project properties were getting added directly to the Deterministic Ignition Location datasheet. Like so:

`DeterministicIgnitionLocation$WeatherZone <- WeatherZoneTable$Name`

If the number of rows (x) in this datasheet was not divisible by the number of weather/fire zones, then an error would be thrown (see screenshot).

I updated this code to randomly sample the weather / fire from the project properties table x number of times and add this to the Deterministic Ignition Locations datasheet instead. 

Let me know if the order of the weather / fire zones matter though.
![Picture1](https://github.com/user-attachments/assets/a1885f43-0340-4f6b-9547-34bb2465ceeb)
