### PR TITLE
Add median date field for season definitions

### DIFF
--- a/src/ignitions.R
+++ b/src/ignitions.R
@@ -123,6 +123,16 @@ if (!isDatasheetEmpty(DeterministicIgnitionLocation)) {
   updateRunLog("Values in Deterministic Ignition Location datasheet are overwritten.", type = "warning")
 }
 
+# If the ignition distribution table is used but one or more season, cause, or firezone are defined but not explicitly listed,
+# these values will be randomly assigned to each ignition with equal probability. Warn users if this behaviour is used.
+if (!isDatasheetEmpty(IgnitionDistribution)) {
+  if (
+    (!isDatasheetEmpty(SeasonTable)   & any(is.na(IgnitionDistribution$Season))) |
+    (!isDatasheetEmpty(CauseTable)    & any(is.na(IgnitionDistribution$Cause))) |
+    (!isDatasheetEmpty(FireZoneTable) & any(is.na(IgnitionDistribution$FireZone))))
+      updateRunLog("One or more of Season, Cause, and Fire Zone are defined at the project scope but not completely described by the Ignition Distribution table. Unspecified values will be drawn randomly where appropriate.", type = "warning")
+}
+
 ## Check raster inputs for consistency ----
 
 test.point <- vect(xyFromCell(fuelsRaster,1), crs = crs(fuelsRaster))
@@ -379,13 +389,23 @@ DeterminisiticIgnitionLocation <-
         firezone = IgnitionDistribution$FireZone[situation]) %>%
       dplyr::select(-situation)
 
-  # If the Ignition Distribution table is not present, choose these values randomly
+  # If the Ignition Distribution table is not present, set these values as empty strings to be filled in the next step
     } else
       mutate(.,
-        season =   sample(SeasonTable$Name,   nrow(.), replace = T),
-        cause =    sample(CauseTable$Name,    nrow(.), replace = T),
-        firezone = sample(FireZoneTable$Name, nrow(.), replace = T))
+        season =   NA_character_,
+        cause =    NA_character_,
+        firezone = NA_character_)
   } %>%
+
+  # If any season, cause, or firezones values are blank, replace with a random sample from the appropriate table of definitions, 
+  # - Note that values could be NA or "", so we first standardize all to NA then correct
+  mutate(.,
+     season =   na_if(as.character(season), ""),
+     firezone = na_if(as.character(firezone), ""),
+     cause =    na_if(as.character(cause), ""),
+     season =   coalesce(season,   sample(SeasonTable$Name,   length(season),   replace = T)),
+     cause =    coalesce(cause,    sample(CauseTable$Name,    length(cause),    replace = T)),
+     firezone = coalesce(firezone, sample(FireZoneTable$Name, length(firezone), replace = T))) %>%
 
   # Group the data by season, cause and firezone and send to
   # sampleLocations() to sample ignition location accordingly

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package name="burnP3Plus" displayName = "BurnP3+" description="Burn probability modeling" url="https://burnp3.github.io/BurnP3Plus/" version="2.0.0">
+<package name="burnP3Plus" displayName = "BurnP3+" description="Burn probability modeling" url="https://burnp3.github.io/BurnP3Plus/" version="2.1.0">
 
 	<!--Library Datasheets-->
 
@@ -22,8 +22,9 @@
 	<dataSheet name="Season" displayName="Seasons" displayMember="Name" autoGroup="True" filter="IsAuto IS NULL OR IsAuto=0" dataScope="Project">
 		<column name="Name" dataType="String"/>
 		<column name="Description" dataType="String" isOptional="True"/>
+		<column name="JulianDay" displayName="Median Julian Day" dataType="Integer" validationCondition="Between" formula1="1" formula2="364" defaultValue="182" allowDbNull="False" />
 		<column name="IsAuto" dataType="Integer" isVisible="False"/>
-		<record columns="Name|IsAuto" values="All|-1"/>
+		<record columns="Name|JulianDay|IsAuto" values="All|182|-1"/>
 	</dataSheet>
 
 	<dataSheet name="Cause" displayName="Causes" displayMember="Name" dataScope="Project">

--- a/src/package.xml
+++ b/src/package.xml
@@ -323,7 +323,7 @@
 	</dataSheet>
 
 	<dataSheet name="OutputFirePerimeter" displayName="Output Fire Perimeters">
-		<column name="Iteration" dataType="Integer" validationType="WholeNumber" validationCondition="Greater" formula1="0" format="d"/>
+		<column name="Iteration" dataType="Integer" validationType="WholeNumber" validationCondition="GreaterEqual" formula1="0" format="d"/>
 		<column name="FireID" dataType="Integer"/>
 		<column name="Timestep" dataType="Integer" validationType="WholeNumber" validationCondition="GreaterEqual" formula1="0" format="d" isVisible="False"/>
 		<column name="FileName" displayName="Burn Perimeter" dataType="String" allowDbNull="False" isExternalFile="True" isRaster="False" includeExtensions="shp|shx|dbf|prj" externalFileFilter="ShapeFiles (*.shp)|*.shp"/>
@@ -377,6 +377,7 @@
 	<transformer name="BurnRasterMap" displayName="Burn Map by Iteration" isExport="True" dataSheet="OutputBurnMap" column="FileName" isFolderExport="True"></transformer>
 	<transformer name="BurnCountRasterMap" displayName="Burn Count Map" isExport="True" dataSheet="OutputBurnCount" column="FileName" isFolderExport="True"></transformer>
 	<transformer name="BurnProbabilityRasterMap" displayName="Burn Probability Map" isExport="True" dataSheet="OutputBurnProbability" column="FileName" isFolderExport="True"></transformer>
+	<transformer name="FirePerimeters" displayName="Burn Perimeters by Iteration and FireID" isExport="True" dataSheet="OutputFirePerimeter" column="FileName" isFolderExport="True"></transformer>
 	<transformer name="AllPerimRasterMap" displayName="Burn Map by Iteration and FireID" isExport="True" dataSheet="OutputAllPerim" column="FileName" isFolderExport="True"></transformer>
 
 	<!--Layouts-->
@@ -385,6 +386,7 @@
 	<layout type="Export">
 		<group name="Export">
 			<item name="BurnRasterMap" displayName="Burn Maps"/>
+			<item name="FirePerimeters" displayName="Individual Fire Burn Perimeters"/>
 			<item name="AllPerimRasterMap" displayName="Individual Fire Burn Maps"/>
 			<item name="BurnCountRasterMap" displayName="Burn Count Map"/>
 			<item name="BurnProbabilityRasterMap" displayName="Burn Probability Map"/>

--- a/src/updates/update-2.100.xml
+++ b/src/updates/update-2.100.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<update comment="Add median date to season, default to July 1st">
+  <action code="Exec" condition="TableExists" criteria="burnP3Plus_Season">
+    <item> ALTER TABLE burnP3Plus_Season ADD COLUMN JulianDay Integer</item>
+    <item> UPDATE burnP3Plus_Season SET JulianDay = 182 WHERE JulianDay IS NULL </item>
+  </action>
+</update>


### PR DESCRIPTION
An XML change and DB Update that **requires** users to provide a median date for each season. This is passed to the fire models which are expected to use this to set things like Foliar Moisture Content in conjunction with the location.

The DB Update and the "All" season default to using July 1st on a non-leap year (Julian day 182) as the median date. This changes the previous default behaviour of the Prometheus and FireSTARR add-ons which used January 1st and June 1st respectively as their hard-coded mock fire date. 