### PR TITLE
Fix unintuitive inheritance of resampling options

### DIFF
--- a/src/ignitions.R
+++ b/src/ignitions.R
@@ -99,7 +99,7 @@ if(isDatasheetEmpty(IgnitionsPerIteration)) {
 }
 
 if(isDatasheetEmpty(ResampleOption)) {
-  updateRunLog("No Minimum Fire Size chosen.\nDefaulting to a Minimum Fire Size of 1ha and drawing 10% extra fires for resampling.\nPlease see the Fire Resampling Options table for more details.", type = "info")
+  updateRunLog("No Minimum Fire Size chosen.\nDefaulting to a Minimum Fire Size of 0ha and with no extra fires. \nPlease see the Fire Resampling Options table for more details.", type = "info")
   ResampleOption[1,] <- c(0,0)
   saveDatasheet(myScenario, ResampleOption, "burnP3Plus_FireResampleOption")
 }

--- a/src/ignitions.R
+++ b/src/ignitions.R
@@ -100,7 +100,7 @@ if(isDatasheetEmpty(IgnitionsPerIteration)) {
 
 if(isDatasheetEmpty(ResampleOption)) {
   updateRunLog("No Minimum Fire Size chosen.\nDefaulting to a Minimum Fire Size of 1ha and drawing 10% extra fires for resampling.\nPlease see the Fire Resampling Options table for more details.", type = "info")
-  ResampleOption[1,] <- c(1,0.1)
+  ResampleOption[1,] <- c(0,0)
   saveDatasheet(myScenario, ResampleOption, "burnP3Plus_FireResampleOption")
 }
 

--- a/src/package.xml
+++ b/src/package.xml
@@ -66,7 +66,6 @@
 	<dataSheet name="FireResampleOption" displayName="Fire Resampling Options" isSingleRow="True">
 		<column name="MinimumFireSize" displayName="Minimum Fire Size (ha)" dataType="Double" defaultValue="0" validationType="Decimal" validationCondition="GreaterEqual" formula1="0"/>
 		<column name="ProportionExtraIgnition" displayName="Proportion of Extra Ignitions to Sample for Replacing Fires below Minimum Size" dataType="Double" defaultValue="0" validationType="Decimal" validationCondition="GreaterEqual" formula1="0.0"/>
-		<record columns="MinimumFireSize|ProportionExtraIgnition" values="0|0"/>
 	</dataSheet>
 
 	<dataSheet name="LandscapeRasters" displayName="Landscape Maps" isSingleRow="True">


### PR DESCRIPTION
A default resampling option record in the package XML prevented manually-set resampling options from being inherited through dependencies. This is especially a problem since resampling options matter for both ignition sampling and fire growth, which are often in separate scenarios with dependencies.

This PR removes the default record and updates the validation in the ignition transformer to reflect the behaviour that was present in the default record. (The old default in the transformer validation was to set a minumum fire size of 1ha and resampling portion of 10%, now we default to no resampling.)