### PR TITLE
Fix avg calculation + double counting first layer

### DIFF
--- a/src/burnProbability.R
+++ b/src/burnProbability.R
@@ -681,7 +681,7 @@ if (saveFBPMaps) {
       if(statistic == "Average") {
 
         fbpSummaryMap <- rast(fbpStack[[1]], vals = NA_real_)
-        for(thisLayer in 2:nlyr(fbpStack)) {
+        for(thisLayer in seq(nlyr(fbpStack))) {
           fbpSummaryMap <- sum(fbpSummaryMap, fbpStack[[thisLayer]], na.rm = T)
         }
         fbpSummaryMap <- fbpSummaryMap / burnCountRasters[["All"]] # Divide by burn count instead of number of layers
@@ -689,14 +689,14 @@ if (saveFBPMaps) {
       } else if(statistic == "Minimum") {
 
         fbpSummaryMap <- rast(fbpStack[[1]], vals = NA_real_)
-        for(thisLayer in 2:nlyr(fbpStack)) {
+        for(thisLayer in seq(nlyr(fbpStack))) {
           fbpSummaryMap <- min(fbpSummaryMap, fbpStack[[thisLayer]], na.rm = T)
         }
 
       } else if(statistic == "Maximum") {
 
         fbpSummaryMap <- rast(fbpStack[[1]], vals = NA_real_)
-        for(thisLayer in 2:nlyr(fbpStack)) {
+        for(thisLayer in seq(nlyr(fbpStack))) {
           fbpSummaryMap <- max(fbpSummaryMap, fbpStack[[thisLayer]], na.rm = T)
         }
 

--- a/src/burnProbability.R
+++ b/src/burnProbability.R
@@ -465,7 +465,8 @@ if(saveBurnMaps) {
     discard(is.null)
   
   # Check that there are outputs to summarize
-  if(length(burnMapRasters) > 0) {
+  # Need burn count raster if the average FBP map is chosen
+  if((length(burnMapRasters) > 0) | saveFBPMaps) {
     
     # Initialize the SyncroSim progress bar
     progressBar("begin", totalSteps = length(burnMapRasters))
@@ -680,22 +681,22 @@ if (saveFBPMaps) {
       if(statistic == "Average") {
 
         fbpSummaryMap <- rast(fbpStack[[1]], vals = NA_real_)
-        for(thisLayer in seq(nlyr(fbpStack))) {
+        for(thisLayer in 2:nlyr(fbpStack)) {
           fbpSummaryMap <- sum(fbpSummaryMap, fbpStack[[thisLayer]], na.rm = T)
         }
-        fbpSummaryMap <- fbpSummaryMap / nlyr(fbpStack)
+        fbpSummaryMap <- fbpSummaryMap / burnCountRasters[["All"]] # Divide by burn count instead of number of layers
 
       } else if(statistic == "Minimum") {
 
         fbpSummaryMap <- rast(fbpStack[[1]], vals = NA_real_)
-        for(thisLayer in seq(nlyr(fbpStack))) {
+        for(thisLayer in 2:nlyr(fbpStack)) {
           fbpSummaryMap <- min(fbpSummaryMap, fbpStack[[thisLayer]], na.rm = T)
         }
 
       } else if(statistic == "Maximum") {
 
         fbpSummaryMap <- rast(fbpStack[[1]], vals = NA_real_)
-        for(thisLayer in seq(nlyr(fbpStack))) {
+        for(thisLayer in 2:nlyr(fbpStack)) {
           fbpSummaryMap <- max(fbpSummaryMap, fbpStack[[thisLayer]], na.rm = T)
         }
 


### PR DESCRIPTION
This branch has the following changes:

1. Fixes the fire intensity average calculation so instead of dividing by the number of layers in raster stack, it divides the sum of the fire intensities by the burn count.
2. The burn count raster is now generated if the FBP outputs are chosen (this may need to be fine tuned a bit more to be specific to average fire intensity).
3. Fixed bug in fire intensity summary calculations where the first layer is always double-counted (not really an issue for min/max, but more of an issue for the average calculation).